### PR TITLE
JSON objects are parsed as stdClass by default

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -19,17 +19,18 @@ class Parser
     /**
      * @param string $filePath
      * @param callback|callable $itemCallback
+     * @param bool $assoc
      *
      * @throws \Exception
      */
-    public function parse($filePath, $itemCallback)
+    public function parse($filePath, $itemCallback, $assoc = false)
     {
         $this->checkCallback($itemCallback);
 
         $stream = $this->openFile($filePath);
 
         try {
-            $listener = new Listener($itemCallback);
+            $listener = new Listener($itemCallback, $assoc);
             $this->parser = new \JsonStreamingParser\Parser(
                 $stream,
                 $listener,

--- a/tests/BasicTest.php
+++ b/tests/BasicTest.php
@@ -49,7 +49,26 @@ class BasicTest extends \PHPUnit_Framework_TestCase
         $filePath = TEST_DATA_PATH . '/basic.json';
         $this->parser->parse(
             $filePath,
-            [$this, 'processItem']
+            [$this, 'processItem'],
+            false
+        );
+
+        $correctData = json_decode(file_get_contents($filePath), false);
+        $this->assertEquals($correctData, $this->items);
+    }
+
+    /**
+     *
+     */
+    public function testAssoc()
+    {
+        $this->items = [];
+
+        $filePath = TEST_DATA_PATH . '/basic.json';
+        $this->parser->parse(
+            $filePath,
+            [$this, 'processItem'],
+            true
         );
 
         $correctData = json_decode(file_get_contents($filePath), true);
@@ -74,7 +93,8 @@ class BasicTest extends \PHPUnit_Framework_TestCase
         $filePath = TEST_DATA_PATH . '/basic.json';
         $this->parser->parse(
             $filePath,
-            [$this, 'processFirstItem']
+            [$this, 'processFirstItem'],
+            true
         );
 
         $correctData = json_decode(file_get_contents($filePath), true);


### PR DESCRIPTION
Parsing as associative arrays can be configured by $assoc parameter.
